### PR TITLE
Quick fix to match the bucket copy script on the readme

### DIFF
--- a/reference_implementations/gcp/vertex/deploy_llama_3_1_from_garden.py
+++ b/reference_implementations/gcp/vertex/deploy_llama_3_1_from_garden.py
@@ -18,7 +18,7 @@ model_name = "llama3.1"
 if model_id is not None:
     model = aiplatform.Model(f"projects/{PROJECT_NUMBER}/locations/{TFVARS['region']}/models/{model_id}@{model_version}")
 else:
-    model_path = f"gs://{TFVARS['project']}-model/llama-garden/llama3.1/Meta-Llama-3.1-8B-Instruct"
+    model_path = f"gs://{TFVARS['project']}-model/llama-garden/Meta-Llama-3.1-8B-Instruct"
     vllm_args = [
         "python",
         "-m",


### PR DESCRIPTION
Looks like the folder structure when the llama 3.1 model is copied over does not match with the script. Here I'm fixing that issue.